### PR TITLE
Atari support for TF534r2c

### DIFF
--- a/boards/Makefile
+++ b/boards/Makefile
@@ -4,7 +4,7 @@ endif
 export TARGET
 
 ifeq ($(TARGET), ATARI)
-BOARDS:=tf534r2c
+BOARDS:=tf534r2c tf530r3
 else
 BOARDS:=tf520 tf530r2 tf530r3 tf534r2c
 endif

--- a/boards/Makefile
+++ b/boards/Makefile
@@ -1,4 +1,15 @@
+ifndef TARGET
+	TARGET=AMIGA
+endif
+export TARGET
+
+ifeq ($(TARGET), ATARI)
+BOARDS:=tf534r2c
+else
 BOARDS:=tf520 tf530r2 tf530r3 tf534r2c
+endif
+
+
 .PHONY: $(BOARDS)
 FOLDER:=tf53x_`date +"%Y_%m_%d"`
 all: clean
@@ -6,7 +17,7 @@ all: clean
 	mkdir ./$(FOLDER)
 	@- $(foreach BOARD,$(BOARDS), make -C $(BOARD); \
 	cp $(BOARD)/*.jed ./$(FOLDER);)
-	zip $(FOLDER)_alpha.zip ./$(FOLDER)/*
+	zip $(FOLDER)_$(TARGET)_alpha.zip ./$(FOLDER)/*
 	rm -rf $(FOLDER)
 clean: 
 	@- $(foreach BOARD,$(BOARDS), make -C $(BOARD) clean;)

--- a/boards/Makefile.cpld
+++ b/boards/Makefile.cpld
@@ -23,6 +23,10 @@ ifndef OPTMODE
        OPTMODE:=Area
 endif
 
+ifndef TARGET
+       TARGET=AMIGA
+endif
+
 ifdef NOWAIT
 PARAMS:=-generics NOWAIT=1
 endif
@@ -62,7 +66,7 @@ PB=$(WD)/$(PN)
 # Output configuration file
 OUTPUT=$(PN).svf
 
-XSTFLAGS=-opt_mode $(OPTMODE) -opt_level 2 -verilog2001 YES -keep_hierarchy No -netlist_hierarchy As_Optimized -rtlview Yes -hierarchy_separator / -bus_delimiter <> -case Maintain -fsm_extract YES -fsm_encoding Auto -safe_implementation No -mux_extract Yes -resource_sharing YES -iobuf YES -pld_mp YES -pld_xp YES -pld_ce YES -wysiwyg NO -equivalent_register_removal YES 
+XSTFLAGS=-define {$(TARGET)} -opt_mode $(OPTMODE) -opt_level 2 -verilog2001 YES -keep_hierarchy No -netlist_hierarchy As_Optimized -rtlview Yes -hierarchy_separator / -bus_delimiter <> -case Maintain -fsm_extract YES -fsm_encoding Auto -safe_implementation No -mux_extract Yes -resource_sharing YES -iobuf YES -pld_mp YES -pld_xp YES -pld_ce YES -wysiwyg NO -equivalent_register_removal YES 
 CPLDFITFLAGS=-slew slow -power std -terminate float -unused float -optimize $(OPTIMIZE) -pterms 50 -loc on -keepio -exhaust
 
 .PHONY: all clean

--- a/boards/tf530r3/Makefile
+++ b/boards/tf530r3/Makefile
@@ -1,6 +1,10 @@
 REVISION=3
 BOARD=tf530
 
+ifndef TARGET
+	TARGET=AMIGA
+endif
+
 RTLFOLDER=../../rtl/
 BUSSOURCES="./$(BOARD)r$(REVISION)_bus_top.v $(RTLFOLDER)/bus_top.v  $(RTLFOLDER)/m6800.v $(RTLFOLDER)/ata.v  $(RTLFOLDER)/bus_delay.v"
 RAMSOURCES="./$(BOARD)r$(REVISION)_ram_top.v $(RTLFOLDER)/ram_top.v $(RTLFOLDER)/fastram.v $(RTLFOLDER)/gayle.v $(RTLFOLDER)/zxmmc.v $(RTLFOLDER)/autoconfig_zii.v"
@@ -9,11 +13,11 @@ RAMSOURCES="./$(BOARD)r$(REVISION)_ram_top.v $(RTLFOLDER)/ram_top.v $(RTLFOLDER)
 all: $(BOARD)r$(REVISION)
 $(BOARD)r$(REVISION): clean $(BOARD)r$(REVISION)_ram $(BOARD)r$(REVISION)_bus
 $(BOARD)r$(REVISION)_ram:
-	make -f ../Makefile.cpld BOARD=$(BOARD) SOURCES=$(RAMSOURCES) SUBPROJ=ram REVISION=$(REVISION) OPTMODE=speed OPTIMISE=speed
+	make -f ../Makefile.cpld TARGET=$(TARGET) BOARD=$(BOARD) SOURCES=$(RAMSOURCES) SUBPROJ=ram REVISION=$(REVISION) OPTMODE=speed OPTIMISE=speed
 $(BOARD)r$(REVISION)_bus:
-	make -f ../Makefile.cpld BOARD=$(BOARD) SOURCES=$(BUSSOURCES) SUBPROJ=bus REVISION=$(REVISION) OPTMODE=speed OPTIMISE=speed
+	make -f ../Makefile.cpld TARGET=$(TARGET) BOARD=$(BOARD) SOURCES=$(BUSSOURCES) SUBPROJ=bus REVISION=$(REVISION) OPTMODE=speed OPTIMISE=speed
 zip: distclean $(BOARD)r$(REVISION)
-	zip $(BOARD)r$(REVISION)_`date +"%Y_%m_%d"`_alpha.zip *.jed
+	zip $(BOARD)r$(REVISION)_$(TARGET)_`date +"%Y_%m_%d"`_alpha.zip *.jed
 clean:	
 	rm -rf work _xmsgs *.zip xlnx_*
 distclean: clean

--- a/boards/tf534r2c/Makefile
+++ b/boards/tf534r2c/Makefile
@@ -1,6 +1,10 @@
 REVISION=2c
 BOARD=tf534
 
+ifndef TARGET
+	TARGET=AMIGA
+endif
+
 RTLFOLDER=../../rtl/
 BUSSOURCES="$(RTLFOLDER)/bus_top.v  $(RTLFOLDER)/m6800.v $(RTLFOLDER)/ata.v  $(RTLFOLDER)/bus_delay.v"
 RAMSOURCES="$(RTLFOLDER)/ram_top.v $(RTLFOLDER)/fastram.v $(RTLFOLDER)/gayle.v $(RTLFOLDER)/zxmmc.v $(RTLFOLDER)/autoconfig.v $(RTLFOLDER)/intreqr.v"
@@ -9,11 +13,11 @@ RAMSOURCES="$(RTLFOLDER)/ram_top.v $(RTLFOLDER)/fastram.v $(RTLFOLDER)/gayle.v $
 all: $(BOARD)r$(REVISION)
 $(BOARD)r$(REVISION): clean $(BOARD)r$(REVISION)_ram $(BOARD)r$(REVISION)_bus
 $(BOARD)r$(REVISION)_ram:
-	make -f ../Makefile.cpld BOARD=$(BOARD) SOURCES=$(RAMSOURCES) SUBPROJ=ram REVISION=$(REVISION) OPTMODE=speed OPTIMISE=speed TOP=ram_top
+	make -f ../Makefile.cpld TARGET=$(TARGET) BOARD=$(BOARD) SOURCES=$(RAMSOURCES) SUBPROJ=ram REVISION=$(REVISION) OPTMODE=speed OPTIMISE=speed TOP=ram_top
 $(BOARD)r$(REVISION)_bus:
-	make -f ../Makefile.cpld BOARD=$(BOARD) SOURCES=$(BUSSOURCES) SUBPROJ=bus REVISION=$(REVISION) OPTMODE=speed OPTIMISE=speed TOP=bus_top
+	make -f ../Makefile.cpld TARGET=$(TARGET) BOARD=$(BOARD) SOURCES=$(BUSSOURCES) SUBPROJ=bus REVISION=$(REVISION) OPTMODE=speed OPTIMISE=speed TOP=bus_top
 zip: distclean $(BOARD)r$(REVISION)
-	zip $(BOARD)r$(REVISION)_`date +"%Y_%m_%d"`_alpha.zip *.jed
+	zip $(BOARD)r$(REVISION)_$(TARGET)_`date +"%Y_%m_%d"`_alpha.zip *.jed
 clean:	
 	rm -rf work _xmsgs *.zip
 distclean: clean

--- a/rtl/ata.v
+++ b/rtl/ata.v
@@ -55,7 +55,11 @@ WAIT                         \_____/
 */
 
 // decode directly from AS and Address Bus.
+`ifndef ATARI
 wire GAYLE_IDE = ({A[23:15]} != {8'hDA,1'b0});
+`else
+wire GAYLE_IDE = ({A[23:16]} != {8'hF0});
+`endif
 
 reg ASDLY = 1'b1;
 reg ASDLY2 = 1'b1;
@@ -102,7 +106,12 @@ assign IOR = IOR_INT;
 assign IOW = IOW_INT ;
 assign DTACK = DTACK_INT;
 
+`ifndef ATARI
 assign IDECS = A[12] ? {GAYLE_IDE, 1'b1} : {1'b1, GAYLE_IDE};
+`else
+assign IDECS = A[5] ? {GAYLE_IDE, 1'b1} : {1'b1, GAYLE_IDE};
+`endif
+
 assign ACCESS = GAYLE_IDE;
 
 

--- a/rtl/autoconfig.v
+++ b/rtl/autoconfig.v
@@ -136,7 +136,11 @@ end
 // decode the base addresses
 // these are hardcoded to the address they always get assigned to.
 assign DECODE[SPI_CARD] = ({A[31:16]} != {16'h00e9}) | shutup[SPI_CARD];
+`ifndef ATARI
 assign DECODE[RAM_CARD] = ({A[31:24]} != {8'h40}) | shutup[RAM_CARD];
+`else
+assign DECODE[RAM_CARD] = ({A[31:22]} != {8'h01, 2'b00}) | shutup[RAM_CARD];    // 4MB TT-RAM
+`endif
 
 assign ACCESS = Z2_ACCESS;
 assign DOUT = data_out;

--- a/rtl/autoconfig_zii.v
+++ b/rtl/autoconfig_zii.v
@@ -126,7 +126,11 @@ end
 // decode the base addresses
 // these are hardcoded to the address they always get assigned to.
 assign DECODE[SPI_CARD] = ({A[23:16]} != {8'he9}) | shutup[SPI_CARD];
+`ifndef ATARI
 assign DECODE[RAM_CARD] = ({A[23:21]} != {3'b001}) | shutup[RAM_CARD];
+`else
+assign DECODE[RAM_CARD] = ({A[31:21]} != {8'h01, 3'b000}) | shutup[RAM_CARD];    // 2MB TT-RAM
+`endif
 
 assign ACCESS = Z2_ACCESS;
 assign DOUT = data_out;

--- a/rtl/bus_top.v
+++ b/rtl/bus_top.v
@@ -105,10 +105,12 @@ wire IACK = CPUSPACE & ({A[19:16]} === {4'b1111});
 wire BUS_BUSY = BGACK & BGACK_INT;
 wire HIGHZ = ~BUS_BUSY | ~INTCYCLE | ~GAYLE_IDE;
 
+`ifndef ATARI
 reg INT2_ASSERT = 1'b0;
 reg INT2_INT = 1'b0;
 reg INT2_IACK_INT = 1'b0;
 wire INT2_IACK = IACK & ({A[3:1]} == 3'b010) & ~AS20;
+`endif
 
 wire DSACK1_SYNC;
 wire VMA_SYNC;
@@ -296,6 +298,8 @@ always @(posedge CLKCPU or posedge AS20) begin
 
 end
 
+`ifndef ATARI
+
 always @(posedge CLKCPU) begin
 
     // INTCYCLE USED TO SHUT OFF THE BUS
@@ -319,6 +323,17 @@ always @(negedge INT2_INT, posedge INT2_IACK_INT) begin
 
 end
 
+`else
+
+always @(posedge CLKCPU) begin
+
+    // INTCYCLE USED TO SHUT OFF THE BUS
+    BUSEN_D <= ~INTCYCLE | AS_INT;
+end
+
+`endif
+
+
 wire VMA_INT = VMA_SYNC;
 
 assign RW =   HIGHZ ? 1'bz : RW_INT;
@@ -335,6 +350,11 @@ assign AVEC = AVEC_INT;
 assign BERR = (CPCS_INT | ~CPSENSE) ? 1'bz : 1'b0;
 assign CPCS = CPCS_INT;
 assign BUSEN = BUSEN_D;
+
+`ifndef ATARI
 assign IPL[2:1] = INT2_ASSERT ? {2'b10} : {2'bzz};
+`else
+assign IPL[2:1] = {2'bzz};
+`endif
 
 endmodule

--- a/rtl/ram_top.v
+++ b/rtl/ram_top.v
@@ -73,6 +73,8 @@ reg STERM_D2 = 1'b1;
 wire ROM_ACCESS = (A[23:19] != {4'hF, 1'b1}) | AS20;
 
 // produce an internal data strobe
+
+`ifndef ATARI
 wire GAYLE_INT2;
 
 wire INT2_STERM;
@@ -116,6 +118,19 @@ gayle GAYLE(
 
 );
 
+`else
+
+wire GAYLE_INT2 = IDEINT ? 1'b0 : 1'bz;
+
+wire INT2_STERM = 1'b1;
+wire INT2_INTCYCLE = 1'b1;
+wire INT2_IDEWAIT = 1'b1;
+
+reg gayle_access = 1'b1;
+wire gayle_decode = 1'b1;
+wire gayle_dout = 1'b0;
+
+`endif
 
 reg spi_access = 1'b1;
 wire spi_decode;


### PR DESCRIPTION
- Onboard ram made available as TT-RAM (Atari FastRAM)
- IDE interface mapped for Atari
- IDE interrupt wired to INT2 (connect to ASCI10 for IDE support under Atari TOS. Not necessary under EmuTOS)
